### PR TITLE
Fix (android) correct accelerometer orientation detection logic

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/screenorientation/CapacitorScreenOrientationPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/screenorientation/CapacitorScreenOrientationPlugin.java
@@ -263,17 +263,17 @@ public class CapacitorScreenOrientationPlugin extends Plugin implements SensorEv
             // Device is relatively flat, use x/y to determine orientation
             if (Math.abs(x) > Math.abs(y)) {
                 // Landscape orientation
-                return x > 0 ? "landscape-secondary" : "landscape-primary";
+                return x > 0 ? "landscape-primary" : "landscape-secondary";
             } else {
                 // Portrait orientation
-                return y > 0 ? "portrait-secondary" : "portrait-primary";
+                return y > 0 ? "portrait-primary" : "portrait-secondary";
             }
         } else {
             // Device is tilted, use strongest axis
             if (Math.abs(x) > threshold && Math.abs(x) > Math.abs(y)) {
-                return x > 0 ? "landscape-secondary" : "landscape-primary";
+                return x > 0 ? "landscape-primary" : "landscape-secondary";
             } else if (Math.abs(y) > threshold) {
-                return y > 0 ? "portrait-secondary" : "portrait-primary";
+                return y > 0 ? "portrait-primary" : "portrait-secondary";
             }
         }
 


### PR DESCRIPTION
## Description
Fixes a bug where the motion-based orientation tracking was returning opposite orientation values (e.g., reporting "landscape-primary" when the device was actually in "landscape-secondary"). While iOS was reporting it correctly.

## Problem
The `determinePhysicalOrientation` method had inverted logic in the ternary operators that map accelerometer values to orientation strings. This caused the plugin to report incorrect orientations when `bypassOrientationLock` was enabled.

## Solution
Corrected the ternary operator conditions in `determinePhysicalOrientation`:
- `landscape-primary`: now correctly returns when `x > 0`
- `landscape-secondary`: now correctly returns when `x < 0`
- `portrait-primary`: now correctly returns when `y > 0`
- `portrait-secondary`: now correctly returns when `y < 0`
- Fixes issue #4 

## Testing
Tested on Android device with motion tracking enabled:
- ✅ Portrait-primary now correctly detected
- ✅ Portrait-secondary now correctly detected
- ✅ Landscape-primary now correctly detected
- ✅ Landscape-secondary now correctly detected

## Changes
- Modified `determinePhysicalOrientation` method in `CapacitorScreenOrientationPlugin.java`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen orientation detection so the app more reliably recognizes primary landscape and primary portrait when the device is tilted or held flat, reducing incorrect orientation switches, layout jumps and flicker during rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->