### PR TITLE
Filter out noise when flat to reduce calls (Android)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
 dist
 node_modules
+**/build/**
+**/android/app/src/main/assets/**

--- a/android/src/main/java/ee/forgr/capacitor/screenorientation/CapacitorScreenOrientationPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/screenorientation/CapacitorScreenOrientationPlugin.java
@@ -266,6 +266,6 @@ public class CapacitorScreenOrientationPlugin extends Plugin implements SensorEv
             return y > 0 ? "portrait-secondary" : "portrait-primary";
         }
         // Default to current if unclear
-        return currentPhysicalOrientation; 
+        return currentPhysicalOrientation;
     }
 }

--- a/android/src/main/java/ee/forgr/capacitor/screenorientation/CapacitorScreenOrientationPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/screenorientation/CapacitorScreenOrientationPlugin.java
@@ -258,28 +258,14 @@ public class CapacitorScreenOrientationPlugin extends Plugin implements SensorEv
         // X axis: left/right tilt
         // Y axis: forward/backward tilt
         // Z axis: up/down (gravity when flat)
-
-        if (Math.abs(z) > 8) {
-            // Device is relatively flat, use x/y to determine orientation
-            if (Math.abs(x) > threshold && Math.abs(x) > Math.abs(y)) {
-                // Landscape orientation
-                return x > 0 ? "landscape-secondary" : "landscape-primary";
-            } else if (Math.abs(y) > threshold) {
-                // Portrait orientation
-                return y > 0 ? "portrait-secondary" : "portrait-primary";
-            }
-            // Default to current if unclear
-            return currentPhysicalOrientation;
-        } else {
-            // Device is tilted, use strongest axis
-            if (Math.abs(x) > threshold && Math.abs(x) > Math.abs(y)) {
-                return x > 0 ? "landscape-secondary" : "landscape-primary";
-            } else if (Math.abs(y) > threshold) {
-                return y > 0 ? "portrait-secondary" : "portrait-primary";
-            }
+        if (Math.abs(x) > threshold && Math.abs(x) > Math.abs(y)) {
+            // Landscape orientation
+            return x > 0 ? "landscape-secondary" : "landscape-primary";
+        } else if (Math.abs(y) > threshold) {
+            // Portrait orientation
+            return y > 0 ? "portrait-secondary" : "portrait-primary";
         }
-
         // Default to current if unclear
-        return currentPhysicalOrientation;
+        return currentPhysicalOrientation; 
     }
 }

--- a/android/src/main/java/ee/forgr/capacitor/screenorientation/CapacitorScreenOrientationPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/screenorientation/CapacitorScreenOrientationPlugin.java
@@ -261,13 +261,15 @@ public class CapacitorScreenOrientationPlugin extends Plugin implements SensorEv
 
         if (Math.abs(z) > 8) {
             // Device is relatively flat, use x/y to determine orientation
-            if (Math.abs(x) > Math.abs(y)) {
+            if (Math.abs(x) > threshold && Math.abs(x) > Math.abs(y)) {
                 // Landscape orientation
                 return x > 0 ? "landscape-secondary" : "landscape-primary";
-            } else {
+            } else if (Math.abs(y) > threshold) {
                 // Portrait orientation
                 return y > 0 ? "portrait-secondary" : "portrait-primary";
             }
+            // Default to current if unclear
+            return currentPhysicalOrientation;
         } else {
             // Device is tilted, use strongest axis
             if (Math.abs(x) > threshold && Math.abs(x) > Math.abs(y)) {

--- a/ios/Sources/CapacitorScreenOrientationPlugin/CapacitorScreenOrientationPlugin.swift
+++ b/ios/Sources/CapacitorScreenOrientationPlugin/CapacitorScreenOrientationPlugin.swift
@@ -52,7 +52,7 @@ public class CapacitorScreenOrientationPlugin: CAPPlugin, CAPBridgedPlugin {
         // Skip system orientation changes when motion tracking is active
         // to avoid duplicate events
         guard !isTrackingWithMotion else { return }
-        
+
         let orientation = UIDevice.current.orientation
         if orientation.isValidInterfaceOrientation {
             notifyOrientationChange(fromDeviceOrientation: orientation)


### PR DESCRIPTION
## What
- when the device is flat in android it now determines if it is above a threshold. If below that threshold then it's just noise.

## Why
- When an android device was flat it would capture and return many different orientations from the listener due to noise. See below.
<img width="642" height="306" alt="Screenshot 2026-02-10 at 1 10 42 PM" src="https://github.com/user-attachments/assets/baae1a2f-cc11-4a31-a3b1-4b7a2a382a9b" />
.
## How
-Used the same threshold and logic found in the else branch for determinePhysicalOrientation(). Prior to this there was no threshold the device would report back constant noise to the listener when flat.

## Testing
-Tested on Samsung Galaxy A16

## Not Tested
-Non samsung devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent device orientation detection across different positions (fewer false "flat" readings).
  * Improved threshold-based logic for clearer landscape/portrait determination.
  * Stronger fallback behavior when orientation is ambiguous to maintain stable app orientation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->